### PR TITLE
Delete character confirmation dialog added

### DIFF
--- a/arena-sessions/src/hooks/useCharacters.ts
+++ b/arena-sessions/src/hooks/useCharacters.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { Character } from '@/models';
 import { CreateCharacterRequest } from '@/pages/api/characters/create';
+import { AppDispatch, clearCharacterSelection } from '@/store';
 
 const getAllRoute = '/api/characters/all';
 const createRoute = '/api/characters/create';
@@ -29,6 +31,7 @@ export interface useCharactersResult {
  *      const { isLoading, characters } = useCharacters();
  */
 export function useCharacters() {
+  const dispatch = useDispatch<AppDispatch>();
   const [characters, setCharacters] = useState<Character[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -79,6 +82,7 @@ export function useCharacters() {
       });
 
       await getCharacters();
+      dispatch(clearCharacterSelection());
     } catch (err) {
       console.error(err);
     } finally {

--- a/arena-sessions/src/pages/character-menu/CharacterMenu.tsx
+++ b/arena-sessions/src/pages/character-menu/CharacterMenu.tsx
@@ -7,20 +7,27 @@ import Character from './Character';
 import CreateCharacterDialog from './dialogs/CreateCharacterDialog';
 import StyledButton from '@/tools/StyledButton';
 import { CreateCharacterRequest } from '../api/characters/create';
-import { AppState, selectSelectedCharacter } from '@/store';
+import { AppDispatch, selectSelectedCharacter } from '@/store';
+import DeleteCharacterDialog from './dialogs/DeleteCharacterDialog';
 import styles from './CharacterMenu.module.css';
 
 /**
  * Component responsible for displaying the character menu on the right side of the screen
  */
 const CharacterMenu: FunctionComponent = () => {
+  const selectedCharacter = useSelector(selectSelectedCharacter);
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] =
+    useState<boolean>(false);
+
+  // Characters hook
   const { isLoading, characters, createCharacter, deleteCharacter } =
     useCharacters();
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const selectedCharacter = useSelector(selectSelectedCharacter);
 
   useEffect(() => {
     setShowCreateDialog(false);
+    setShowDeleteDialog(false);
   }, []);
 
   if (isLoading) {
@@ -49,6 +56,12 @@ const CharacterMenu: FunctionComponent = () => {
         onClose={() => setShowCreateDialog(false)}
         onSubmit={(char) => handleCreate(char)}
       />
+
+      <DeleteCharacterDialog
+        isVisible={showDeleteDialog && selectedCharacter != null}
+        onClose={() => setShowDeleteDialog(false)}
+        onSubmit={() => handleDelete()}
+      />
     </div>
   );
 
@@ -63,7 +76,7 @@ const CharacterMenu: FunctionComponent = () => {
           <div key={char.id}>
             <Character
               character={char}
-              deleteCharacter={deleteCharacter}
+              deleteCharacter={() => setShowDeleteDialog(true)}
               selectedId={selectedCharacter?.id.toString()}
             />
           </div>
@@ -77,6 +90,13 @@ const CharacterMenu: FunctionComponent = () => {
   async function handleCreate(char: CreateCharacterRequest) {
     setShowCreateDialog(false);
     await createCharacter(char);
+  }
+
+  async function handleDelete() {
+    if (selectedCharacter != null) {
+      await deleteCharacter(selectedCharacter.id);
+      setShowDeleteDialog(false);
+    }
   }
 };
 

--- a/arena-sessions/src/pages/character-menu/dialogs/CreateCharacterDialog.tsx
+++ b/arena-sessions/src/pages/character-menu/dialogs/CreateCharacterDialog.tsx
@@ -47,6 +47,7 @@ const CreateCharacterDialog: FunctionComponent<
   return (
     <StyledDialog
       isVisible={isVisible}
+      submitText="Create"
       title="Create character"
       onClose={onClose}
       onSubmit={() => handleSubmit()}

--- a/arena-sessions/src/pages/character-menu/dialogs/DeleteCharacterDialog.tsx
+++ b/arena-sessions/src/pages/character-menu/dialogs/DeleteCharacterDialog.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { FunctionComponent, useState } from 'react';
+
+import StyledDialog from '@/tools/StyledDialog';
+
+/**
+ * Props for the DeleteCharacterDialog component
+ */
+export interface DeleteCharacterDialogProps {
+  isVisible: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+/**
+ * Responsible for handling the delete character dialog menu
+ */
+const DeleteCharacterDialog: FunctionComponent<
+  DeleteCharacterDialogProps
+> = (props) => {
+  const { isVisible, onClose, onSubmit } = props;
+
+  const [prevIsVisible, setPrevIsVisible] = useState(isVisible);
+  if (prevIsVisible != isVisible) {
+    setPrevIsVisible(isVisible);
+  }
+
+  return (
+    <StyledDialog
+      isVisible={isVisible}
+      title="Delete character"
+      onClose={onClose}
+      onSubmit={onSubmit}
+    >
+      <div>
+        <div>Are you sure you want to delete this character?</div>
+        <div>
+          Deleting a character also results in all session data being
+          deleted.
+        </div>
+        <br />
+        <div>Confirm below to proceed with the deletion.</div>
+      </div>
+    </StyledDialog>
+  );
+};
+
+export default DeleteCharacterDialog;

--- a/arena-sessions/src/pages/character-menu/dialogs/index.ts
+++ b/arena-sessions/src/pages/character-menu/dialogs/index.ts
@@ -1,1 +1,2 @@
 export * from './CreateCharacterDialog';
+export * from './DeleteCharacterDialog';

--- a/arena-sessions/src/tools/StyledDialog.tsx
+++ b/arena-sessions/src/tools/StyledDialog.tsx
@@ -10,6 +10,7 @@ export interface StyledDialogProps {
   children?: any;
   isVisible: boolean;
   title: string;
+  submitText?: string;
   onClose: () => void;
   onSubmit: () => void;
 }
@@ -20,7 +21,14 @@ export interface StyledDialogProps {
 const StyledDialog: FunctionComponent<StyledDialogProps> = (
   props
 ) => {
-  const { children, isVisible, title, onClose, onSubmit } = props;
+  const {
+    children,
+    isVisible,
+    submitText,
+    title,
+    onClose,
+    onSubmit,
+  } = props;
 
   if (!isVisible) {
     return null;
@@ -38,7 +46,7 @@ const StyledDialog: FunctionComponent<StyledDialogProps> = (
           <StyledButton
             className={styles.buttonPadding}
             isPrimary={true}
-            text="Create"
+            text={submitText ?? 'Submit'}
             onClick={onSubmit}
           />
           <StyledButton


### PR DESCRIPTION
Added a confirmation dialog for deleting a character.
Opening the delete dialog menu now selects that character in the store.
In a later body of work I will add the character's details into the confirmation dialog.

![image](https://github.com/austinbatye/ArenaSessions/assets/36509220/1a6d9acd-ae45-4587-b60b-28d7a5ead9a7)
